### PR TITLE
Shippreviewzoom scroll distances and speed

### DIFF
--- a/flplusplus.ini
+++ b/flplusplus.ini
@@ -26,7 +26,12 @@ remove_start_location_warning = true
 log_to_console = false
 ; Scrolling speed when zooming in/out in the ship preview window
 ; Setting this value to 0 disables this scrolling feature entirely
-ship_preview_scrolling_speed = 2
+; When using the distance factor below, this speed is the base speed at 0 distance.
+ship_preview_scrolling_speed = 1
+; Allows increasing the scrolling speed depending on the currently zoomed distance.
+; Actual Zoom Speed = ZoomDistance * ScrollingSpeed * DistanceFactor
+; Set to 0 to disable speeding up of zoom.
+ship_preview_scrolling_speed_distance_factor = 0.1
 ; Reverse scrolling direction when zooming in/out in the ship preview window
 ship_preview_scrolling_inverse = false
 ; The minimum distance the player can zoom to the ship. Can be negative to allow zoom "through" the ship.

--- a/flplusplus.ini
+++ b/flplusplus.ini
@@ -29,3 +29,7 @@ log_to_console = false
 ship_preview_scrolling_speed = 2
 ; Reverse scrolling direction when zooming in/out in the ship preview window
 ship_preview_scrolling_inverse = false
+; The minimum distance the player can zoom to the ship. Can be negative to allow zoom "through" the ship.
+ship_preview_scrolling_min_distance = 0
+; The maximum distance the player can zoom away from the ship.
+ship_preview_scrolling_max_distance = 100

--- a/flplusplus/src/config.cpp
+++ b/flplusplus/src/config.cpp
@@ -20,7 +20,8 @@ void config::init_defaults()
     conf.screenshotsindirectory = false;
     conf.removestartlocationwarning = true;
     conf.logtoconsole = false;
-    conf.shippreviewscrollingspeed = 2;
+    conf.shippreviewscrollingspeed = 1;
+    conf.shippreviewscrollingspeeddistancefactor = 0.1f;
     conf.shippreviewscrollinginverse = false;
     conf.shippreviewscrollingmindistance = 0.0f;
     conf.shippreviewscrollingmaxdistance = 100.0f;
@@ -68,6 +69,9 @@ void config::init_from_file(const char *filename)
 
             if (reader.is_value("ship_preview_scrolling_speed"))
                 conf.shippreviewscrollingspeed = reader.get_value_float(0);
+
+            if (reader.is_value("ship_preview_scrolling_speed_distance_factor"))
+                conf.shippreviewscrollingspeeddistancefactor = reader.get_value_float(0);
 
             if (reader.is_value("ship_preview_scrolling_inverse"))
                 conf.shippreviewscrollinginverse = reader.get_value_bool(0);

--- a/flplusplus/src/config.cpp
+++ b/flplusplus/src/config.cpp
@@ -22,6 +22,8 @@ void config::init_defaults()
     conf.logtoconsole = false;
     conf.shippreviewscrollingspeed = 2;
     conf.shippreviewscrollinginverse = false;
+    conf.shippreviewscrollingmindistance = 0.0f;
+    conf.shippreviewscrollingmaxdistance = 100.0f;
 }
 void config::init_from_file(const char *filename)
 {
@@ -69,6 +71,12 @@ void config::init_from_file(const char *filename)
 
             if (reader.is_value("ship_preview_scrolling_inverse"))
                 conf.shippreviewscrollinginverse = reader.get_value_bool(0);
+
+            if (reader.is_value("ship_preview_scrolling_min_distance"))
+                conf.shippreviewscrollingmindistance = reader.get_value_float(0);
+
+            if (reader.is_value("ship_preview_scrolling_max_distance"))
+                conf.shippreviewscrollingmaxdistance = reader.get_value_float(0);
         }
     }
 

--- a/flplusplus/src/config.h
+++ b/flplusplus/src/config.h
@@ -21,6 +21,8 @@ namespace config {
         bool logtoconsole;
         float shippreviewscrollingspeed;
         bool shippreviewscrollinginverse;
+        float shippreviewscrollingmindistance;
+        float shippreviewscrollingmaxdistance;
         std::vector<std::string> fontfiles{};
     };
     ConfigData& get_config();

--- a/flplusplus/src/config.h
+++ b/flplusplus/src/config.h
@@ -20,6 +20,7 @@ namespace config {
         bool removestartlocationwarning;
         bool logtoconsole;
         float shippreviewscrollingspeed;
+        float shippreviewscrollingspeeddistancefactor;
         bool shippreviewscrollinginverse;
         float shippreviewscrollingmindistance;
         float shippreviewscrollingmaxdistance;

--- a/flplusplus/src/shippreviewscroll.cpp
+++ b/flplusplus/src/shippreviewscroll.cpp
@@ -7,17 +7,21 @@ using namespace shippreviewscroll;
 
 #define MIN_SCROLLING_SPEED 0.0f
 #define MAX_SCROLLING_SPEED 50.0f
+#define MIN_SCROLLING_SPEED_DISTANCE_FACTOR 0.0f
 
 float scrollingSpeed;
 float scrollMinDistance;
 float scrollMaxDistance;
+float scrollingSpeedDistanceFactor;
 
 bool __fastcall ShipPreviewWindowScroll(ShipPreviewWindow* window, PVOID _edx, ScrollDirection dir)
 {
+    const float factoredScroll = abs(window->zoomLevel) * scrollingSpeed * scrollingSpeedDistanceFactor + scrollingSpeed;
+
     if (dir == ScrollDirection::up)
-        window->zoomLevel += scrollingSpeed;
+        window->zoomLevel += factoredScroll;
     else if (dir == ScrollDirection::down)
-        window->zoomLevel -= scrollingSpeed;
+        window->zoomLevel -= factoredScroll;
 
     // Zoom levels are always negative if you "zoom away" from the ship.
     // If you want to zoom "through" the ship, it becomes positive.
@@ -41,6 +45,7 @@ void shippreviewscroll::init()
 
     scrollMinDistance = config::get_config().shippreviewscrollingmindistance;
     scrollMaxDistance = config::get_config().shippreviewscrollingmaxdistance;
+    scrollingSpeedDistanceFactor = max(MIN_SCROLLING_SPEED_DISTANCE_FACTOR, config::get_config().shippreviewscrollingspeeddistancefactor);
 
     // Every window in Freelancer has a virtual "scroll" function
     // In the case of the ship preview window, this function does basically nothing

--- a/flplusplus/src/shippreviewscroll.cpp
+++ b/flplusplus/src/shippreviewscroll.cpp
@@ -9,6 +9,8 @@ using namespace shippreviewscroll;
 #define MAX_SCROLLING_SPEED 50.0f
 
 float scrollingSpeed;
+float scrollMinDistance;
+float scrollMaxDistance;
 
 bool __fastcall ShipPreviewWindowScroll(ShipPreviewWindow* window, PVOID _edx, ScrollDirection dir)
 {
@@ -16,6 +18,10 @@ bool __fastcall ShipPreviewWindowScroll(ShipPreviewWindow* window, PVOID _edx, S
         window->zoomLevel += scrollingSpeed;
     else if (dir == ScrollDirection::down)
         window->zoomLevel -= scrollingSpeed;
+
+    // Zoom levels are always negative if you "zoom away" from the ship.
+    // If you want to zoom "through" the ship, it becomes positive.
+    window->zoomLevel = max(-scrollMaxDistance, min(-scrollMinDistance, window->zoomLevel));
 
     // The scroll function should just return false
     return false;
@@ -32,6 +38,9 @@ void shippreviewscroll::init()
 
     if (config::get_config().shippreviewscrollinginverse)
         scrollingSpeed *= -1;
+
+    scrollMinDistance = config::get_config().shippreviewscrollingmindistance;
+    scrollMaxDistance = config::get_config().shippreviewscrollingmaxdistance;
 
     // Every window in Freelancer has a virtual "scroll" function
     // In the case of the ship preview window, this function does basically nothing


### PR DESCRIPTION
This PR adds two new features:
- a range in which the ship preview zoom distance is limited to. The min-range can be negative too.
- a speed-up factor based on the scroll speed and current zoom distance for the ship preview.
The speed-up uses a linear function which feels, by my personal taste, to be just enough. The default value for the scroll speed has been adjusted as this mimicks the previous behaviour on vanilla-scaled ships.
The speed of zoom behaves as follows with the default values:
![367842741-9edeb469-92b8-4294-8e35-014c5bfc66d1](https://github.com/user-attachments/assets/e9206001-f5a6-462e-89c5-f29c6f41023c)
