### PR TITLE
Adjust description for LOD scaling to be more precise about what it a…

### DIFF
--- a/flplusplus.ini
+++ b/flplusplus.ini
@@ -1,20 +1,19 @@
 ; Settings file for flplusplus
 [flplusplus]
-; Multiplier for render distance and the distance at which LODs are switched.
+; Multiplier for maximum render distance and the distance at which LODs are switched.
+; The maximum render distance is assumed to be 10,000 at a scaling factor of 1.
 ; Supports decimal values
-; 1 = no change from vanilla Freelancer
+; 0 = disables the feature (for mods using own values)
+; 1 = use vanilla Freelancer values
 ; 2 = Double render distance & LOD switch threshold
 ; 3.5 = 3.5x render distance & LOD switch threshold, etc.
 lod_scale = 1
 pbubble_scale = 1
 character_detail_scale = 1
-; save_folder_name
 ; Name of the save folder in Documents/My Games
 save_folder_name = Freelancer
-; save_in_directory
 ; if true, save in the game directory (EXE/../SAVE) instead of Documents/My Games
 save_in_directory = false
-; screenshots_folder_name
 ; Name of the screenshots folder in Pictures
 screenshots_folder_name = FreelancerShots
 ; screenshots_in_directory


### PR DESCRIPTION
The LOD scaling feature also scales the max render distance. This one assumes a base value of 10,000. This wasn't clear before and just caused me some major confusion.
By how it is programmed the scaling values below 1.0f do disable the feature (unintentionally?)